### PR TITLE
use all instead of bin for gradle distribution

### DIFF
--- a/jvm-packages/contributions/airlearner/gradle/wrapper/gradle-wrapper.properties
+++ b/jvm-packages/contributions/airlearner/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Wed May 10 11:02:20 PDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-rc-2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-rc-2-all.zip


### PR DESCRIPTION
Using `gradle-3.5-rc-2-all.zip` instead of `gradle-3.5-rc-2-bin.zip` lets IntelliJ access Gradle sources, which helps with writing build files.

@jq @jieyingchen 