### PR TITLE
Airlearner uses its own .gitignore

### DIFF
--- a/jvm-packages/contrib/airlearner/.gitignore
+++ b/jvm-packages/contrib/airlearner/.gitignore
@@ -1,1 +1,14 @@
+# Allow airlearner to control its own .gitignore (don't inherit parent .gitignore)
+!*
+
+# Ignore IDE settings
+.idea
+
+# Ignore Gradle build directory
 /.gradle
+
+# Ignore build artifacts
+build
+
+# Ignore generated files
+*.log


### PR DESCRIPTION
Don't use the repo root-level .gitignore. Control our own for airlearner since we have different files/buildsystem.

@jq @jieyingchen 